### PR TITLE
Updating EOT2008 and EOT2012 sizes

### DIFF
--- a/data-2008.md
+++ b/data-2008.md
@@ -17,13 +17,13 @@ To assist with exploring and using the dataset, we provide gzipped files which l
 
 By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/** to each line, you end up with the s3 and HTTP paths respectively.
 
-|       File      | List	                                                                                                      | #Files | Total Size <br/> Compressed (TiB)|
+|       File      | List	                                                                                                      | #Files | Total Size <br/> Compressed|
 |-----------------|-------------------------------------------------------------------------------------------------------------|--------|----------------------------------|
 | Segments        | [EOT-2008/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/segment.paths.gz)       | 14     |                                  |
-| WARC files      | [EOT-2008/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/warc.paths.gz)             | 125704 | 16.85                             |
-| WAT files       | [EOT-2008/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/wat.paths.gz)               | 125704 |  0.48                             |
-| WET files       | [EOT-2008/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/wet.paths.gz)               | 125704 |  0.12                             |
-| CDX files       | [EOT-2008/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/cdx.paths.gz)               | 125704 |  0.01                            |
-| URL Index files | [EOT-2008/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/eot-index.paths.gz)   | 50     |  0.007                                |
+| WARC files      | [EOT-2008/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/warc.paths.gz)             | 125704 | 15.32 TB                             |
+| WAT files       | [EOT-2008/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/wat.paths.gz)               | 125704 | 447.08 GB                             |
+| WET files       | [EOT-2008/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/wet.paths.gz)               | 125704 | 108.1 GB                             |
+| CDX files       | [EOT-2008/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/cdx.paths.gz)               | 125704 | 9.41 GB                            |
+| URL Index files | [EOT-2008/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/eot-index.paths.gz)   | 49     | 7 GB                                |
 
 

--- a/data-2012.md
+++ b/data-2012.md
@@ -17,12 +17,12 @@ To assist with exploring and using the dataset, we provide gzipped files which l
 
 By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/** to each line, you end up with the s3 and HTTP paths respectively.
 
-|       File      | List	                                                                                                      | #Files | Total Size <br/> Compressed (TiB)|
+|       File      | List	                                                                                                      | #Files | Total Size <br/> Compressed |
 |-----------------|-------------------------------------------------------------------------------------------------------------|--------|----------------------------------|
 | Segments        | [EOT-2012/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/segment.paths.gz)       | 10     |                                  |
-| WARC files      | [EOT-2012/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/warc.paths.gz)             | 78509  | 45.57                             |
-| WAT files       | [EOT-2012/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/wat.paths.gz)               | 78509  |  0.95                             |
-| WET files       | [EOT-2012/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/wet.paths.gz)               | 78509  |  0.23                             |
-| CDX files       | [EOT-2012/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/cdx.paths.gz)               | 78509  |  0.01                            |
-| URL Index files | [EOT-2012/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/eot-index.paths.gz)   | 50     |  0.01                                |
+| WARC files      | [EOT-2012/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/warc.paths.gz)             | 78509  | 41.42 TB                             |
+| WAT files       | [EOT-2012/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/wat.paths.gz)               | 78509  |  885.15 GB                             |
+| WET files       | [EOT-2012/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/wet.paths.gz)               | 78509  |  217.3 GB                             |
+| CDX files       | [EOT-2012/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/cdx.paths.gz)               | 78509  |  12.27 GB                            |
+| URL Index files | [EOT-2012/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/eot-index.paths.gz)   | 50     |  9.9 GB                                |
 

--- a/data-2012.md
+++ b/data-2012.md
@@ -24,5 +24,5 @@ By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/*
 | WAT files       | [EOT-2012/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/wat.paths.gz)               | 78509  |  885.15 GB                             |
 | WET files       | [EOT-2012/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/wet.paths.gz)               | 78509  |  217.3 GB                             |
 | CDX files       | [EOT-2012/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/cdx.paths.gz)               | 78509  |  12.27 GB                            |
-| URL Index files | [EOT-2012/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/eot-index.paths.gz)   | 50     |  9.9 GB                                |
+| URL Index files | [EOT-2012/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/eot-index.paths.gz)   | 49     |  9.9 GB                                |
 

--- a/data.md
+++ b/data.md
@@ -13,7 +13,9 @@ The work of inventorying, staging and moving the data into AWS is still ongoing 
 
 Currently we have these datasets partially available for use. 
 
-| Dataset                      | WARC #  | WARC Size <br/> Compressed (TiB) | 
+| Dataset                      | WARC #  | WARC Size <br/> Compressed       | 
 |------------------------------|---------|----------------------------------|
-| [EOT-2008](/data/data-2008/) | 125704  | 16.85                            |
-| [EOT-2012](/data/data-2012/) | 78509   | 45.57                            |
+| [EOT-2008](/data/data-2008/) | 125704  | 15.32 TB                         |
+| [EOT-2012](/data/data-2012/) | 78509   | 41.42 TB                         |
+| EOT-2016                     |         |                                  |
+| EOT-2020                     |         |                                  |


### PR DESCRIPTION
Realized the numbers were off from what is in AWS.  Wrote a script that in theory should calculate these correctly now.