### PR TITLE
Clarify titles for Presentations page

### DIFF
--- a/presentations.md
+++ b/presentations.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: Presentations
+title: Media
 permalink: /presentations/
 ---
 
 ## Press
 
-### 2024
+### EOT 2024
 
 Calma, J. (2025, January 18). _The mad dash to protect environmental data from Donald Trump_. The Verge. <a href="https://www.theverge.com/2025/1/18/24346025/data-donald-trump-climate-environment-epa" data-versionurl="https://web.archive.org/web/20250128170830/https://www.theverge.com/2025/1/18/24346025/data-donald-trump-climate-environment-epa" data-versiondate="2025-01-28">https://www.theverge.com/2025/1/18/24346025/data-donald-trump-climate-environment-epa</a>
 
@@ -23,11 +23,11 @@ Minovi, D. (2024, December 11). _Three Efforts to Preserve Government Data as a 
 Zwarenstein C. (2025, February 5). _As the Trump admin deletes online data, scientists and digital librarians rush to save it_. Salon.
 <a href="https://www.salon.com/2025/02/04/as-the-admin-deletes-online-data-scientists-and-digital-librarians-rush-to-save-it/" data-versionurl="https://web.archive.org/web/20250204175119/https://www.salon.com/2025/02/04/as-the-admin-deletes-online-data-scientists-and-digital-librarians-rush-to-save-it/" data-versiondata="2025-01-31">https://www.salon.com/2025/02/04/as-the-admin-deletes-online-data-scientists-and-digital-librarians-rush-to-save-it/</a>
 
-### 2020
+### EOT 2020
 
 Shapiro, C. (2021, April 20). _How Government Agencies Archive the White House’s Electronic Records_. FedTech Magazine. <a href="https://fedtechmagazine.com/article/2021/04/how-government-agencies-archive-white-houses-electronic-records" data-versionurl="https://web.archive.org/web/20210420175406/https://fedtechmagazine.com/article/2021/04/how-government-agencies-archive-white-houses-electronic-records" data-versiondate="2021-04-20">https://fedtechmagazine.com/article/2021/04/how-government-agencies-archive-white-houses-electronic-records</a>
 
-### 2016
+### EOT 2016
 
 Young, L. J. (2017, December 15) _The Librarians Saving The Internet_. Science Friday. <a href="https://apps.sciencefriday.com/data/librarians.html" data-versionurl="https://web.archive.org/web/20171215182156/https://apps.sciencefriday.com/data/librarians.html" data-versiondate="2017-12-15">https://apps.sciencefriday.com/data/librarians.html</a>
 


### PR DESCRIPTION
This changes the title of presentations.md to be more representative of including press citations. It also prefixes the year subtitles with "EOT" to hopefully clarify the year is representative of the round of End of Term project we are on, not the year in which a work was created.