### PR TITLE
Data 2024 branch

### DIFF
--- a/data-2024.md
+++ b/data-2024.md
@@ -18,16 +18,16 @@ To assist with exploring and using the dataset, we provide gzipped files which l
 
 By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/** to each line, you end up with the s3 and HTTP paths respectively.
 
-|       File      | List	                                                                                                      | #Files  | Total Size <br/> Compressed |
-|-----------------|-------------------------------------------------------------------------------------------------------------|---------|-----------------------------|
-| Segments        | [EOT-2024/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/segment.paths.gz)       | 128     |                             |
-| WARC files      | [EOT-2024/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/warc.paths.gz)             | 1216891 |  2.29 PB                    |
-| WAT files       | [EOT-2024/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/wat.paths.gz)               | 1216891 |  18.22 TB                   |
-| WET files       | [EOT-2024/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/wet.paths.gz)               | 1216891 |  7.27 TB                    |
-| META files      | [EOT-2024/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/meta.paths.gz)             | 1216891 |  1.73 TB                    |
-| CDX files       | [EOT-2024/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/cdx.paths.gz)               | 1216891 |  285.71 GB                  |
-| STATS files     | [EOT-2024/stats.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/stats.paths.gz)           | 1216891 |  426.45 MB                  |
-| URL Index files | [EOT-2024/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/eot-index.paths.gz)   | 73      |  238 GB                     |
+|       File      | List	                                                                                                    |   #Files  | Total Size <br/> Compressed |
+| :---            | :---                                                                                                        |      ---: |                        ---: |
+| Segments        | [EOT-2024/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/segment.paths.gz)       | 128       |                             |
+| WARC files      | [EOT-2024/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/warc.paths.gz)             | 1,216,891 |  2.29 PB                    |
+| WAT files       | [EOT-2024/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/wat.paths.gz)               | 1,216,891 |  18.22 TB                   |
+| WET files       | [EOT-2024/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/wet.paths.gz)               | 1,216,891 |  7.27 TB                    |
+| META files      | [EOT-2024/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/meta.paths.gz)             | 1,216,891 |  1.73 TB                    |
+| CDX files       | [EOT-2024/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/cdx.paths.gz)               | 1,216,891 |  285.71 GB                  |
+| STATS files     | [EOT-2024/stats.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/stats.paths.gz)           | 1,216,891 |  426.45 MB                  |
+| URL Index files | [EOT-2024/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/eot-index.paths.gz)   | 73        |  238 GB                     |
 
 ## License
 

--- a/data-2024.md
+++ b/data-2024.md
@@ -37,7 +37,7 @@ There are no restrictions on the use, access, and/or download of data from the E
 	author       = {Alam, Sawood and Phillips, Mark Edward},
 	year         = 2026,
 	publisher    = {End of Term Web Archive},
-	url          = {https://eotarchive.org/data/data-2020/}
+	url          = {https://eotarchive.org/data/data-2024/}
 }
 
 ```

--- a/data-2024.md
+++ b/data-2024.md
@@ -1,0 +1,30 @@
+---
+layout: page
+title: End of Term 2024 Dataset
+permalink: /data/data-2024/
+---
+
+# End of Term 2024 Dataset
+
+The End of Term 2024 Dataset represents data collected by six collecting institutions. These institutions were ArchiveTeam (AT), Common Crawl Foundation (CC), 
+The Library Innovation Lab at Harvard Law School (HIL), Internet Archive (IA), University of North Texas Libraries (UNT), and Webrecorder (WR). The data is 
+part of the initiative called the End of Term Presidential Web Archive.  
+
+## Archive Location and Download
+
+The 2024 End of Term archive is located on the **eotarchive** bucket at [EOT-2024](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/index.html).
+
+To assist with exploring and using the dataset, we provide gzipped files which list all segments, WARC, WAT, WET, META, and CDX files.
+
+By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/** to each line, you end up with the s3 and HTTP paths respectively.
+
+|       File      | List	                                                                                                      | #Files  | Total Size <br/> Compressed |
+|-----------------|-------------------------------------------------------------------------------------------------------------|---------|-----------------------------|
+| Segments        | [EOT-2024/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/segment.paths.gz)       | 128     |                             |
+| WARC files      | [EOT-2024/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/warc.paths.gz)             | 1216891 |  2.29 PB                    |
+| WAT files       | [EOT-2024/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/wat.paths.gz)               | 1216891 |  18.22 TB                   |
+| WET files       | [EOT-2024/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/wet.paths.gz)               | 1216891 |  7.27 TB                    |
+| META files      | [EOT-2024/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/meta.paths.gz)             | 1216891 |  1.73 TB.                   |
+| CDX files       | [EOT-2024/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/cdx.paths.gz)               | 1216891 |  285.71 GB                  |
+| STATS files     | [EOT-2024/stats.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/stats.paths.gz)           | 1216891 |  426.45 MB                  |
+| URL Index files | [EOT-2024/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/eot-index.paths.gz)   | 73      |  238 GB                     |

--- a/data-2024.md
+++ b/data-2024.md
@@ -24,7 +24,7 @@ By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/*
 | WARC files      | [EOT-2024/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/warc.paths.gz)             | 1216891 |  2.29 PB                    |
 | WAT files       | [EOT-2024/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/wat.paths.gz)               | 1216891 |  18.22 TB                   |
 | WET files       | [EOT-2024/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/wet.paths.gz)               | 1216891 |  7.27 TB                    |
-| META files      | [EOT-2024/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/meta.paths.gz)             | 1216891 |  1.73 TB.                   |
+| META files      | [EOT-2024/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/meta.paths.gz)             | 1216891 |  1.73 TB                    |
 | CDX files       | [EOT-2024/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/cdx.paths.gz)               | 1216891 |  285.71 GB                  |
 | STATS files     | [EOT-2024/stats.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/stats.paths.gz)           | 1216891 |  426.45 MB                  |
 | URL Index files | [EOT-2024/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/eot-index.paths.gz)   | 73      |  238 GB                     |

--- a/data-2024.md
+++ b/data-2024.md
@@ -28,3 +28,19 @@ By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/*
 | CDX files       | [EOT-2024/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/cdx.paths.gz)               | 1216891 |  285.71 GB                  |
 | STATS files     | [EOT-2024/stats.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/stats.paths.gz)           | 1216891 |  426.45 MB                  |
 | URL Index files | [EOT-2024/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2024/eot-index.paths.gz)   | 73      |  238 GB                     |
+
+## License
+
+There are no restrictions on the use, access, and/or download of data from the End of Term Web Archive Dataset. We request that you cite the End of Term Web Archive project when using the data provided from this dataset.
+
+## How to Cite
+```
+@misc{EOTDataset2024,
+  author    = {Alam, Sawood and Phillips, Mark Edward},
+  title     = {End of Term 2024 Dataset},
+  year      = {2026},
+  publisher = {End of Term Web Archive},
+  doi       = {TODO},
+  url       = {https://eotarchive.org/data/data-2020/}
+}
+```

--- a/data-2024.md
+++ b/data-2024.md
@@ -4,9 +4,8 @@ title: End of Term 2024 Dataset
 permalink: /data/data-2024/
 ---
 
-The End of Term 2024 Dataset represents data collected by six collecting institutions. These institutions were ArchiveTeam (AT), Common Crawl Foundation (CC), 
-The Library Innovation Lab at Harvard Law School (HIL), Internet Archive (IA), University of North Texas Libraries (UNT), and Webrecorder (WR). The data is 
-part of the initiative called the End of Term Presidential Web Archive.  
+The End of Term 2024 Dataset represents data collected by six collecting institutions from September 2024 through April 2025. These institutions were ArchiveTeam (AT), Common Crawl Foundation (CC), The Library Innovation Lab at Harvard Law School (HIL), Internet Archive (IA), University of North Texas Libraries (UNT), and Webrecorder (WR). 
+The data is part of the initiative called the End of Term Presidential Web Archive.  
 
 ## Archive Location and Download
 

--- a/data-2024.md
+++ b/data-2024.md
@@ -4,8 +4,6 @@ title: End of Term 2024 Dataset
 permalink: /data/data-2024/
 ---
 
-# End of Term 2024 Dataset
-
 The End of Term 2024 Dataset represents data collected by six collecting institutions. These institutions were ArchiveTeam (AT), Common Crawl Foundation (CC), 
 The Library Innovation Lab at Harvard Law School (HIL), Internet Archive (IA), University of North Texas Libraries (UNT), and Webrecorder (WR). The data is 
 part of the initiative called the End of Term Presidential Web Archive.  

--- a/data-2024.md
+++ b/data-2024.md
@@ -36,11 +36,12 @@ There are no restrictions on the use, access, and/or download of data from the E
 ## How to Cite
 ```
 @misc{EOTDataset2024,
-  author    = {Alam, Sawood and Phillips, Mark Edward},
-  title     = {End of Term 2024 Dataset},
-  year      = {2026},
-  publisher = {End of Term Web Archive},
-  doi       = {TODO},
-  url       = {https://eotarchive.org/data/data-2020/}
+	title        = {End of Term 2024 Dataset},
+	author       = {Alam, Sawood and Phillips, Mark Edward},
+	year         = 2026,
+	publisher    = {End of Term Web Archive},
+	doi          = {TODO},
+	url          = {https://eotarchive.org/data/data-2020/}
 }
+
 ```

--- a/data-2024.md
+++ b/data-2024.md
@@ -38,7 +38,6 @@ There are no restrictions on the use, access, and/or download of data from the E
 	author       = {Alam, Sawood and Phillips, Mark Edward},
 	year         = 2026,
 	publisher    = {End of Term Web Archive},
-	doi          = {TODO},
 	url          = {https://eotarchive.org/data/data-2020/}
 }
 

--- a/data.md
+++ b/data.md
@@ -11,11 +11,11 @@ host a copy of the 2004, 2008, 2012, 2016, 2020 and 2024 End of Term Datasets.
 
 The work of inventorying, staging and moving the data into AWS is still ongoing and more information will be provided here in the future. 
 
-Currently we have these datasets partially available for use. 
+Currently we have these datasets available for use. 
 
 | Dataset                      | WARC #  | WARC Size <br/> Compressed       | 
 |------------------------------|---------|----------------------------------|
-| [EOT-2024 (Upload in process)](/data/data-2024/) | 812512  | 1492.8 TB                        |
+| [EOT-2024](/data/data-2024/) | 1216891 | 2.29 PB                          |
 | [EOT-2020](/data/data-2020/) | 239811  | 266.04 TB                        |
 | [EOT-2016](/data/data-2016/) | 194683  | 139.3 TB                         |
 | [EOT-2012](/data/data-2012/) | 78509   | 41.42 TB                         |

--- a/data.md
+++ b/data.md
@@ -13,14 +13,14 @@ The work of inventorying, staging and moving the data into AWS is still ongoing 
 
 Currently we have these datasets available for use. 
 
-| Dataset                      | WARC #  | WARC Size <br/> Compressed       | 
-|------------------------------|---------|----------------------------------|
-| [EOT-2024](/data/data-2024/) | 1216891 | 2.29 PB                          |
-| [EOT-2020](/data/data-2020/) | 239811  | 266.04 TB                        |
-| [EOT-2016](/data/data-2016/) | 194683  | 139.3 TB                         |
-| [EOT-2012](/data/data-2012/) | 78509   | 41.42 TB                         |
-| [EOT-2008](/data/data-2008/) | 125704  | 15.32 TB                         |
-| EOT-2004                     | 58977   | 6.42 TB                          |
+| Dataset                      | WARC #    | WARC Size <br/> Compressed | 
+| :---                         | ---:      | ---:                       |
+| [EOT-2024](/data/data-2024/) | 1,216,891 | 2.29 PB                    |
+| [EOT-2020](/data/data-2020/) | 239,811   | 266.04 TB                  |
+| [EOT-2016](/data/data-2016/) | 194,683   | 139.3 TB                   |
+| [EOT-2012](/data/data-2012/) | 78,509    | 41.42 TB                   |
+| [EOT-2008](/data/data-2008/) | 125,704   | 15.32 TB                   |
+| EOT-2004                     | 58,977    | 6.42 TB                    |
 
 # End of Term Web Crawls Collection
 


### PR DESCRIPTION
This is to add the EOT-2024 dataset to the website and also adjust the data landing page. 