### PR TITLE
Update indexes and EOT-2016 dataset

### DIFF
--- a/data-2004.md
+++ b/data-2004.md
@@ -17,13 +17,12 @@ To assist with exploring and using the dataset, we provide gzipped files which l
 
 By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/** to each line, you end up with the s3 and HTTP paths respectively.
 
-|       File      | List	                                                                                                      | #Files | Total Size <br/> Compressed|
-|-----------------|-------------------------------------------------------------------------------------------------------------|--------|----------------------------------|
-| Segments        | [EOT-2004/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/segment.paths.gz)       | 6      |                                  |
-| WARC files      | EOT-2004/warc.paths.gz                                                                                      | 58977  | 6.42 TB                          |
-| WAT files       | [EOT-2004/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/wat.paths.gz)               | 58977  | 108.34 GB                        |
-| WET files       | [EOT-2004/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/wet.paths.gz)               | 58977  | 18.21 MB                         |
-| META files      | [EOT-2004/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/meta.paths.gz)             | 58977  | 36.27 GB                         |
-| CDX files       | [EOT-2004/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/cdx.paths.gz)               | 58977  | 5.82 GB                          |
-| URL Index files | [EOT-2004/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/eot-index.paths.gz)   | 49     | 4.5 GB                           |
-
+|       File      | List	                                                                                                      | # Files | Total Size <br/> Compressed |
+|-----------------|-------------------------------------------------------------------------------------------------------------|---------|-----------------------------|
+| Segments        | [EOT-2004/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/segment.paths.gz)       | 6       |                             |
+| WARC files      | EOT-2004/warc.paths.gz                                                                                      | 58,977  | 6.42 TB                     |
+| WAT files       | [EOT-2004/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/wat.paths.gz)               | 58,977  | 108.34 GB                   |
+| WET files       | [EOT-2004/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/wet.paths.gz)               | 58,977  | 18.21 MB                    |
+| META files      | [EOT-2004/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/meta.paths.gz)             | 58,977  | 36.27 GB                    |
+| CDX files       | [EOT-2004/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/cdx.paths.gz)               | 58,977  | 5.82 GB                     |
+| URL Index files | [EOT-2004/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2004/eot-index.paths.gz)   | 3       | 4.5 GB                      |

--- a/data-2008.md
+++ b/data-2008.md
@@ -34,7 +34,6 @@ By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/*
 	publisher    = {End of Term Web Archive},
 	url          = {https://eotarchive.org/data/data-2008/}
 }
-
 ```
 
 

--- a/data-2008.md
+++ b/data-2008.md
@@ -15,7 +15,7 @@ To assist with exploring and using the dataset, we provide gzipped files which l
 
 By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/** to each line, you end up with the s3 and HTTP paths respectively.
 
-|       File      | List	                                                                                                      | #Files  | Total Size <br/> Compressed |
+|       File      | List	                                                                                                    | #Files  | Total Size <br/> Compressed |
 | :---            | :---                                                                                                        |   ---:  |                       ---:  |
 | Segments        | [EOT-2008/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/segment.paths.gz)       | 14      |                             |
 | WARC files      | [EOT-2008/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/warc.paths.gz)             | 125,704 | 15.32 TB                    |
@@ -23,7 +23,7 @@ By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/*
 | WET files       | [EOT-2008/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/wet.paths.gz)               | 125,704 | 108.1 GB                    |
 | META files      | [EOT-2008/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/meta.paths.gz)             | 125,704 | 68.49 GB                    |
 | CDX files       | [EOT-2008/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/cdx.paths.gz)               | 125,704 | 9.41 GB                     |
-| URL Index files | [EOT-2008/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/eot-index.paths.gz)   | 49      | 7 GB                        |
+| URL Index files | [EOT-2008/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2008/eot-index.paths.gz)   | 4       | 7 GB                        |
 
 ## How to Cite
 ```

--- a/data-2012.md
+++ b/data-2012.md
@@ -15,7 +15,7 @@ To assist with exploring and using the dataset, we provide gzipped files which l
 
 By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/** to each line, you end up with the s3 and HTTP paths respectively.
 
-|       File      | List	                                                                                                      | #Files  | Total Size <br/> Compressed |
+|       File      | List	                                                                                                    | # Files | Total Size <br/> Compressed |
 | :---            | :---                                                                                                        |   ---:  |                        ---: |
 | Segments        | [EOT-2012/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/segment.paths.gz)       | 10      |                             |
 | WARC files      | [EOT-2012/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/warc.paths.gz)             | 78,509  |  41.42 TB                   |
@@ -23,7 +23,7 @@ By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/*
 | WET files       | [EOT-2012/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/wet.paths.gz)               | 78,509  |  217.3 GB                   |
 | META files      | [EOT-2012/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/meta.paths.gz)             | 78,509  |  81.56 GB                   |
 | CDX files       | [EOT-2012/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/cdx.paths.gz)               | 78,509  |  12.27 GB                   |
-| URL Index files | [EOT-2012/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/eot-index.paths.gz)   | 49      |  9.9 GB                     |
+| URL Index files | [EOT-2012/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2012/eot-index.paths.gz)   | 5       |  9.9 GB                     |
 
 ## How to Cite
 ```

--- a/data-2012.md
+++ b/data-2012.md
@@ -34,5 +34,4 @@ By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/*
 	publisher    = {End of Term Web Archive},
 	url          = {https://eotarchive.org/data/data-2012/}
 }
-
 ```

--- a/data-2016.md
+++ b/data-2016.md
@@ -14,15 +14,15 @@ To assist with exploring and using the dataset, we provide gzipped files which l
 
 By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/** to each line, you end up with the s3 and HTTP paths respectively.
 
-|       File      | List	                                                                                                      | #Files  | Total Size <br/> Compressed |
-| :---            | :---                                                                                                        |     ---: |                       ---: |
-| Segments        | [EOT-2016/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/segment.paths.gz)       | 22       |                            |
-| WARC files      | [EOT-2016/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/warc.paths.gz)             | 194,683  |  139.3 TB                  |
-| WAT files       | [EOT-2016/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/wat.paths.gz)               | 194,683  |  1.7 TB                    |
-| WET files       | [EOT-2016/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/wet.paths.gz)               | 194,683  |  330.81 GB                 |
-| META files       | [EOT-2016/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/meta.paths.gz)            | 194,683  |  167.95 GB                 |
-| CDX files       | [EOT-2016/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/cdx.paths.gz)               | 194,683  |  25.36 GB                  |
-| URL Index files | [EOT-2016/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/eot-index.paths.gz)   | 49       |  23.1 GB                   |
+|       File      | List	                                                                                                    | # Files  | Total Size <br/> Compressed |
+| :---            | :---                                                                                                        |     ---: |                        ---: |
+| Segments        | [EOT-2016/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/segment.paths.gz)       | 22       |                             |
+| WARC files      | [EOT-2016/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/warc.paths.gz)             | 194,683  |  139.3 TB                   |
+| WAT files       | [EOT-2016/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/wat.paths.gz)               | 194,683  |  1.7 TB                     |
+| WET files       | [EOT-2016/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/wet.paths.gz)               | 194,683  |  330.81 GB                  |
+| META files       | [EOT-2016/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/meta.paths.gz)            | 194,683  |  167.95 GB                  |
+| CDX files       | [EOT-2016/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/cdx.paths.gz)               | 194,683  |  25.36 GB                   |
+| URL Index files | [EOT-2016/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/eot-index.paths.gz)   | 9        |  24 GB                      |
 
 ## How to Cite
 ```

--- a/data-2016.md
+++ b/data-2016.md
@@ -17,11 +17,11 @@ By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/*
 |       File      | List	                                                                                                    | # Files  | Total Size <br/> Compressed |
 | :---            | :---                                                                                                        |     ---: |                        ---: |
 | Segments        | [EOT-2016/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/segment.paths.gz)       | 22       |                             |
-| WARC files      | [EOT-2016/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/warc.paths.gz)             | 194,683  |  139.3 TB                   |
-| WAT files       | [EOT-2016/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/wat.paths.gz)               | 194,683  |  1.7 TB                     |
-| WET files       | [EOT-2016/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/wet.paths.gz)               | 194,683  |  330.81 GB                  |
-| META files       | [EOT-2016/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/meta.paths.gz)            | 194,683  |  167.95 GB                  |
-| CDX files       | [EOT-2016/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/cdx.paths.gz)               | 194,683  |  25.36 GB                   |
+| WARC files      | [EOT-2016/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/warc.paths.gz)             | 198,593  |  284 TB                     |
+| WAT files       | [EOT-2016/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/wat.paths.gz)               | 198,593  |  1.7 TB                     |
+| WET files       | [EOT-2016/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/wet.paths.gz)               | 198,593  |  330.8 GB                   |
+| META files       | [EOT-2016/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/meta.paths.gz)            | 198,593  |  175 GB                     |
+| CDX files       | [EOT-2016/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/cdx.paths.gz)               | 198,593  |  26.14 GB                   |
 | URL Index files | [EOT-2016/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2016/eot-index.paths.gz)   | 9        |  24 GB                      |
 
 ## How to Cite

--- a/data-2016.md
+++ b/data-2016.md
@@ -33,5 +33,4 @@ By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/*
 	publisher    = {End of Term Web Archive},
 	url          = {https://eotarchive.org/data/data-2016/}
 }
-
 ```

--- a/data-2020.md
+++ b/data-2020.md
@@ -14,15 +14,15 @@ To assist with exploring and using the dataset, we provide gzipped files which l
 
 By adding either **s3://eotarchive/** or **https://eotarchive.s3.amazonaws.com/** to each line, you end up with the s3 and HTTP paths respectively.
 
-|       File      | List	                                                                                                      | #Files | Total Size <br/> Compressed |
-| :---            | :---                                                                                                        |    --: |                        ---: |
-| Segments        | [EOT-2020/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/segment.paths.gz)       | 26     |                             |
-| WARC files      | [EOT-2020/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/warc.paths.gz)             | 239,811 |  266.04 TB                 |
-| WAT files       | [EOT-2020/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/wat.paths.gz)               | 239,811 |  9.15 TB                   |
-| WET files       | [EOT-2020/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/wet.paths.gz)               | 239,811 |  2.6 TB                    |
-| META files      | [EOT-2020/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/meta.paths.gz)             | 239,811 |  712.66 GB                 |
-| CDX files       | [EOT-2020/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/cdx.paths.gz)               | 239,811 |  83.66 GB                  |
-| URL Index files | [EOT-2020/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/eot-index.paths.gz)   | 49      |  74.4 GB                   |
+|       File      | List	                                                                                                      | # Files | Total Size <br/> Compressed |
+| :---            | :---                                                                                                        |    --:  |                        ---: |
+| Segments        | [EOT-2020/segment.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/segment.paths.gz)       | 26      |                             |
+| WARC files      | [EOT-2020/warc.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/warc.paths.gz)             | 239,811 |  266.04 TB                  |
+| WAT files       | [EOT-2020/wat.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/wat.paths.gz)               | 239,811 |  9.15 TB                    |
+| WET files       | [EOT-2020/wet.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/wet.paths.gz)               | 239,811 |  2.6 TB                     |
+| META files      | [EOT-2020/meta.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/meta.paths.gz)             | 239,811 |  712.66 GB                  |
+| CDX files       | [EOT-2020/cdx.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/cdx.paths.gz)               | 239,811 |  83.66 GB                   |
+| URL Index files | [EOT-2020/eot-index.paths.gz](https://eotarchive.s3.amazonaws.com/crawl-data/EOT-2020/eot-index.paths.gz)   | 28      |  72 GB                      |
 
 ## How to Cite
 ```

--- a/data.md
+++ b/data.md
@@ -22,6 +22,17 @@ Currently we have these datasets available for use.
 | [EOT-2008](/data/data-2008/) | 125,704   | 15.32 TB                   |
 | [EOT-2004](/data/data-2004/) | 58,977    | 6.42 TB                    |
 
-# End of Term Web Crawls Collection
+## How to Cite
+```
+@misc{EOTDataset2008,
+	title        = {End of Term Datasets},
+	author       = {Alam, Sawood and Phillips, Mark Edward},
+	year         = 2026,
+	publisher    = {End of Term Web Archive},
+	url          = {https://eotarchive.org/data/}
+}
+```
+
+## End of Term Web Crawls Collection
 
 Additionally, crawl data is available from the Internet Archive via the [End of Term Web Crawls collection](https://archive.org/details/EndofTermWebCrawls).

--- a/data.md
+++ b/data.md
@@ -17,7 +17,7 @@ Currently we have these datasets available for use.
 | :---                         | ---:      | ---:                       |
 | [EOT-2024](/data/data-2024/) | 1,216,891 | 2.29 PB                    |
 | [EOT-2020](/data/data-2020/) | 239,811   | 266.04 TB                  |
-| [EOT-2016](/data/data-2016/) | 194,683   | 139.3 TB                   |
+| [EOT-2016](/data/data-2016/) | 198,593   | 284 TB                   |
 | [EOT-2012](/data/data-2012/) | 78,509    | 41.42 TB                   |
 | [EOT-2008](/data/data-2008/) | 125,704   | 15.32 TB                   |
 | [EOT-2004](/data/data-2004/) | 58,977    | 6.42 TB                    |


### PR DESCRIPTION
This is to update the data pages for all of the datasets. 

* Parquet indexes were updated
* Formatting of the tables were adjusted a bit to justify columns
* EOT-2016 had all of the numbers adjusted to include the AT-000 FTP data
* Citation added to data.md page.